### PR TITLE
Escape braces for compatibility with perl 5.26

### DIFF
--- a/lib/LaTeX/Decode.pm
+++ b/lib/LaTeX/Decode.pm
@@ -128,14 +128,14 @@ sub latex_decode {
 
     if ( $scheme eq 'full' ) {
         $text =~ s/\\not\\($NEG_SYMB_RE)/$NEGATEDSYMBOLS{$1}/ge;
-        $text =~ s/\\textsuperscript{($SUPER_RE)}/$SUPERSCRIPTS{$1}/ge;
-        $text =~ s/\\textsuperscript{\\($SUPERCMD_RE)}/$CMDSUPERSCRIPTS{$1}/ge;
-        $text =~ s/\\dings{([2-9AF][0-9A-F])}/$DINGS{$1}/ge;
+        $text =~ s/\\textsuperscript\{($SUPER_RE)\}/$SUPERSCRIPTS{$1}/ge;
+        $text =~ s/\\textsuperscript\{\\($SUPERCMD_RE)\}/$CMDSUPERSCRIPTS{$1}/ge;
+        $text =~ s/\\dings\{([2-9AF][0-9A-F])\}/$DINGS{$1}/ge;
     }
 
     $text =~ s/(\\[a-zA-Z]+)\\(\s+)/$1\{\}$2/g;    # \foo\ bar -> \foo{} bar
     $text =~ s/([^{]\\\w)([;,.:%])/$1\{\}$2/g;     #} Aaaa\o, -> Aaaa\o{},
-    $text =~ s/(\\(?:$DIAC_RE_BASE|$ACCENTS_RE)){\\i}/$1\{i\}/g;
+    $text =~ s/(\\(?:$DIAC_RE_BASE|$ACCENTS_RE))\{\\i\}/$1\{i\}/g;
            # special cases such as '\={\i}' -> '\={i}' -> "i\x{304}"
 
     ## remove {} around macros that print one character


### PR DESCRIPTION
See also https://rt.cpan.org/Public/Bug/Display.html?id=110678